### PR TITLE
Use system chrome version by default.

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -4,7 +4,7 @@ let browserOpts = process.env.CHROME_BIN ? {
   type: "exact",
   executablePath: process.env.CHROME_BIN
 } : {
-  type: "canary"
+  type: "system"
 };
 
 const config: {


### PR DESCRIPTION
Seems like a better default (folks are more likely to have `system` than 
`canary`).