### PR TITLE
Ensure assetFingerprint capture is used in local lookup

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -15,6 +15,7 @@ config.servers.forEach(server => {
   startServer(server.name, config.har, server.port, (key, text) => {
     if (server.dist) {
       let assetName, extension;
+      let assetFingerprint = '';
 
       let fingerprinted = typeof server.fingerprinted === 'undefined' || server.fingerprinted === true
 
@@ -23,7 +24,7 @@ config.servers.forEach(server => {
 
         if (!matches) { console.log(key); return text; }
 
-        [,assetName,,extension] = matches;
+        [,assetName,assetFingerprint,extension] = matches;
       } else {
         let matches = key.match(/GET\/(.+)(\.js)$/);
         if (!matches) { console.log('No Match: ', key); return text; }
@@ -31,7 +32,7 @@ config.servers.forEach(server => {
         [,assetName,extension] = matches;
       }
 
-      let localPath = path.join(server.dist, `${assetName}${extension}`);
+      let localPath = path.join(server.dist, `${assetName}${assetFingerprint}${extension}`);
 
       if (fs.existsSync(localPath)) {
         console.log('Looked up on disk: ', localPath);


### PR DESCRIPTION
Previously, the fingerprint capture group was ignored when constructing
`localPath` such that `fs.existsSync('lookupPath')` failed and fell
through.