### PR TITLE
Don't pass fingerprint to assets on disk

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -15,7 +15,6 @@ config.servers.forEach(server => {
   startServer(server.name, config.har, server.port, (key, text) => {
     if (server.dist) {
       let assetName, extension;
-      let assetFingerprint = '';
 
       let fingerprinted = typeof server.fingerprinted === 'undefined' || server.fingerprinted === true
 
@@ -24,7 +23,7 @@ config.servers.forEach(server => {
 
         if (!matches) { console.log(key); return text; }
 
-        [,assetName,assetFingerprint,extension] = matches;
+        [,assetName,,extension] = matches;
       } else {
         let matches = key.match(/GET\/(.+)(\.js)$/);
         if (!matches) { console.log('No Match: ', key); return text; }
@@ -32,7 +31,7 @@ config.servers.forEach(server => {
         [,assetName,extension] = matches;
       }
 
-      let localPath = path.join(server.dist, `${assetName}${assetFingerprint}${extension}`);
+      let localPath = path.join(server.dist, `${assetName}${extension}`);
 
       if (fs.existsSync(localPath)) {
         console.log('Looked up on disk: ', localPath);


### PR DESCRIPTION
The fingerprint changes in https://github.com/krisselden/ember-macro-benchmark/pull/26 seem incorrect. The asset fingerprint from the request should not be looked for on disk.

/cc @rondale-sc 