### PR TITLE
Clarifies the README steps for running the benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ yarn run serve
 
 ### Run the Benchmark
 
+While the app is being served, run:
+
 ```sh
 yarn run bench
 ```


### PR DESCRIPTION
Adds a note clarifying that `yarn run bench` must be run while the app is being served using `yarn run serve`